### PR TITLE
6.0.3

### DIFF
--- a/Cerberus.props
+++ b/Cerberus.props
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <!-- This is the global version and is used for all projects that don't have a version -->
-    <Version Condition="$(Version) == ''">6.0.2</Version>
+    <Version Condition="$(Version) == ''">6.0.3</Version>
     <!-- Enables public beta warning via the PUBLIC_BETA constant -->
     <PublicBeta>false</PublicBeta>
 

--- a/UltimateAFK/Handlers/Components/AFKComponent.cs
+++ b/UltimateAFK/Handlers/Components/AFKComponent.cs
@@ -2,12 +2,10 @@
 using PluginAPI.Core;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NWAPIPermissionSystem;
 using PlayerRoles;
 using PlayerRoles.PlayableScps.Scp079;
 using PlayerRoles.PlayableScps.Scp096;
-using PluginAPI.Core.Items;
 using UltimateAFK.Resources;
 using UnityEngine;
 
@@ -161,27 +159,30 @@ namespace UltimateAFK.Handlers.Components
         public void Replace(Player player, RoleTypeId role)
         {
             // Check if role is blacklisted
-            if (UltimateAFK.Singleton.Config.RoleTypeBlacklist.Contains(role))
+            if (UltimateAFK.Singleton.Config.RoleTypeBlacklist?.Count > 0)
             {
-                Log.Debug($"player {player.Nickname} ({player.UserId}) has a role that is blacklisted so he will not be searched for a replacement player", UltimateAFK.Singleton.Config.DebugMode);
-                player.ClearPlayerInventory();
-                player.SetRole(RoleTypeId.Spectator);
-                
-                if (UltimateAFK.Singleton.Config.AfkCount != -1)
+                if (UltimateAFK.Singleton.Config.RoleTypeBlacklist.Contains(role))
                 {
-                    AfkCount++;
+                    Log.Debug($"player {player.Nickname} ({player.UserId}) has a role that is blacklisted so he will not be searched for a replacement player", UltimateAFK.Singleton.Config.DebugMode);
+                    player.ClearPlayerInventory();
+                    player.SetRole(RoleTypeId.Spectator);
 
-                    if (AfkCount >= UltimateAFK.Singleton.Config.AfkCount)
+                    if (UltimateAFK.Singleton.Config.AfkCount != -1)
                     {
-                        player.SendConsoleMessage(UltimateAFK.Singleton.Config.MsgKick, "white");
-                        player.Kick(UltimateAFK.Singleton.Config.MsgKick);
-                        return;
+                        AfkCount++;
+
+                        if (AfkCount >= UltimateAFK.Singleton.Config.AfkCount)
+                        {
+                            player.SendConsoleMessage(UltimateAFK.Singleton.Config.MsgKick, "white");
+                            player.Kick(UltimateAFK.Singleton.Config.MsgKick);
+                            return;
+                        }
                     }
+
+                    player.SendBroadcast(UltimateAFK.Singleton.Config.MsgFspec, 30, shouldClearPrevious: true);
+                    player.SendConsoleMessage(UltimateAFK.Singleton.Config.MsgFspec, "white");
+                    return;
                 }
-                
-                player.SendBroadcast(UltimateAFK.Singleton.Config.MsgFspec, 30, shouldClearPrevious: true);
-                player.SendConsoleMessage(UltimateAFK.Singleton.Config.MsgFspec, "white");
-                return;
             }
             
             // Get player replacement

--- a/UltimateAFK/UltimateAFK.cs
+++ b/UltimateAFK/UltimateAFK.cs
@@ -17,7 +17,7 @@ namespace UltimateAFK
 
         [PluginConfig] public Config Config;
         
-        [PluginEntryPoint("UltimateAFK", "6.0.2", "Checks if a player is afk for too long and if detected as afk will be replaced by a spectator.", "SrLicht")]
+        [PluginEntryPoint("UltimateAFK", "6.0.3", "Checks if a player is afk for too long and if detected as afk will be replaced by a spectator.", "SrLicht")]
         void OnEnabled()
         {
             Singleton = this;

--- a/UltimateAFK/UltimateAFK.csproj
+++ b/UltimateAFK/UltimateAFK.csproj
@@ -25,8 +25,8 @@
  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Nito.AsyncEx.Tasks" Version="5.1.2" />
-    <PackageReference Include="Northwood.PluginAPI" Version="12.0.0-rc.6" />
-    <PackageReference Include="Northwood.PluginAPI.Analyzers" Version="12.0.0-rc.6" />
+    <PackageReference Include="Northwood.PluginAPI" Version="12.0.0" />
+    <PackageReference Include="Northwood.PluginAPI.Analyzers" Version="12.0.0" />
   <PackageReference Include="YamlDotNet" Version="12.3.1" />
     <PackageReference Include="Lib.Harmony" Version="2.2.2" />
   </ItemGroup>


### PR DESCRIPTION
Updated PluginAPI to 12.0.0
Fixed bug when role_type_blacklist parameter is empty
```
[2023-01-18 12:26:51.967 +02:00] [Error] [UltimateAFK] Player [connId=2] (UltimateAFK.Handlers.Components.AfkComponent) error on CheckAFK: System.NullReferenceException: Object reference not set to an instance of an object
                                   at UltimateAFK.Handlers.Components.AfkComponent.Replace (PluginAPI.Core.Player player, PlayerRoles.RoleTypeId role) [0x00010] in <712875b73e304731a98ab241709d3834>:0
                                   at UltimateAFK.Handlers.Components.AfkComponent.CheckAfk () [0x00277] in <712875b73e304731a98ab241709d3834>:0
                                   at UltimateAFK.Handlers.Components.AfkComponent+<CheckAfkPerSecond>d__15.MoveNext () [0x00076] in <712875b73e304731a98ab241709d3834>:0  ||   at UltimateAFK.Handlers.Components.AfkComponent.Replace (PluginAPI.Core.Player player, PlayerRoles.RoleTypeId role) [0x00010] in <712875b73e304731a98ab241709d3834>:0
                                   at UltimateAFK.Handlers.Components.AfkComponent.CheckAfk () [0x00277] in <712875b73e304731a98ab241709d3834>:0
                                   at UltimateAFK.Handlers.Components.AfkComponent+<CheckAfkPerSecond>d__15.MoveNext () [0x00076] in <712875b73e304731a98ab241709d3834>:0
```