### PR TITLE
6.1.1

### DIFF
--- a/Cerberus.props
+++ b/Cerberus.props
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <!-- This is the global version and is used for all projects that don't have a version -->
-    <Version Condition="$(Version) == ''">6.1.0</Version>
+    <Version Condition="$(Version) == ''">6.1.1</Version>
     <!-- Enables public beta warning via the PUBLIC_BETA constant -->
     <PublicBeta>false</PublicBeta>
 

--- a/UltimateAFK/Command/AfkCommand.cs
+++ b/UltimateAFK/Command/AfkCommand.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using CommandSystem;
+using NWAPIPermissionSystem;
+using PlayerRoles;
+using PlayerRoles.PlayableScps.Scp079;
+using PluginAPI.Commands;
+using PluginAPI.Core;
+using PluginAPI.Core.Attributes;
+using UltimateAFK.Handlers;
+using UltimateAFK.Resources;
+
+namespace UltimateAFK.Command
+{
+    [CommandHandler(typeof(ClientCommandHandler))]
+    public class AfkCommand : ICommand
+    {
+        public string Command { get; } = "afk";
+        public string[] Aliases { get; }
+        public string Description { get; } = "By using this command you will be moved to spectator and if the server allows it a player will replace you."; 
+        
+        public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
+        {
+            try
+            {
+                if (!UltimateAFK.Singleton.Config.CommandConfig.IsEnabled)
+                {
+                    response = UltimateAFK.Singleton.Config.CommandConfig.TextOnDisable;
+                }
+                
+                var ply = Player.Get(sender);
+                
+                GoAfk(ply, ply.Role);
+                response = UltimateAFK.Singleton.Config.CommandConfig.TextOnSucces;
+                return true;
+            }
+            catch (Exception e)
+            {
+                response = $"Error: {e.Data} -- {e}";
+                return false;
+            }
+        }
+
+        private void GoAfk(Player ply, RoleTypeId roleType)
+        {
+                // Check if role is blacklisted
+                if (UltimateAFK.Singleton.Config.RoleTypeBlacklist?.Count > 0 && UltimateAFK.Singleton.Config.RoleTypeBlacklist.Contains(roleType))
+                {
+                    Log.Debug($"In the command | player {ply.Nickname} ({ply.UserId}) has a role that is blacklisted so he will not be searched for a replacement player", UltimateAFK.Singleton.Config.DebugMode);
+                    
+                    ply.ClearInventory();
+                    ply.SetRole(RoleTypeId.Spectator);
+                    
+                    ply.SendBroadcast(UltimateAFK.Singleton.Config.MsgFspec, 30, shouldClearPrevious: true);
+                    ply.SendConsoleMessage(UltimateAFK.Singleton.Config.MsgFspec, "white");
+                    return;
+                }
+                
+                // Get player replacement
+                Player replacement = null;
+
+                if (UltimateAFK.Singleton.Config.CommandConfig.Replace)
+                    replacement = FindReplacement(ply);
+                
+                // If replacement is null
+                if (replacement is null)
+                {
+                    Log.Debug("In the command | Unable to find replacement player, moving to spectator...", UltimateAFK.Singleton.Config.DebugMode);
+                    
+                    ply.ClearInventory();
+                    ply.SetRole(RoleTypeId.Spectator);
+
+                    ply.SendBroadcast(UltimateAFK.Singleton.Config.MsgFspec, 30, shouldClearPrevious: true);
+                    ply.SendConsoleMessage(UltimateAFK.Singleton.Config.MsgFspec, "white");
+                }
+                else
+                {
+                    // if not
+                    Log.Debug($"In the command | Replacement Player found: {replacement.Nickname} ({replacement.UserId})", UltimateAFK.Singleton.Config.DebugMode);
+
+                    // Check if AFK role is SCP-079 
+                    if (roleType is RoleTypeId.Scp079)
+                    {
+                        //Adds the replacement player to the dictionary with all the necessary information
+                        AddData(ply, replacement, true);
+                
+                        // Self-explanatory
+                        ply.SetRole(RoleTypeId.Spectator);
+                        
+                        //Send player a broadcast for being too long afk
+                        ply.SendBroadcast(UltimateAFK.Singleton.Config.MsgFspec, 30, shouldClearPrevious: true);
+                        ply.SendConsoleMessage(UltimateAFK.Singleton.Config.MsgFspec, "white");
+                
+                        // Sends replacement to the role that had the afk
+                        replacement.SetRole(roleType);
+                    }
+                    else
+                    {
+                        // Adds the replacement player to the dictionary with all the necessary information
+                        AddData(ply, replacement, false);
+                        
+                        // Clear player inventory
+                        ply.ClearInventory();
+                        //Send player a broadcast for being too long afk
+                        ply.SendBroadcast(UltimateAFK.Singleton.Config.MsgFspec, 25, shouldClearPrevious: true);
+                        ply.SendConsoleMessage(UltimateAFK.Singleton.Config.MsgFspec, "white");
+                        // Sends player to spectator
+                        ply.SetRole(RoleTypeId.Spectator);
+                        // Sends replacement to the role that had the afk
+                        replacement.SetRole(roleType);
+                    }
+                }
+        }
+
+        private Player FindReplacement(Player afk)
+        {
+            foreach (var player in Player.GetPlayers())
+            {
+                if (player.IsAlive || player == afk || player.CheckPermission("uafk.ignore") || player.IsServer || player.UserId.Contains("@server"))
+                    continue;
+
+                return player;
+            }
+
+            return null;
+        }
+        
+        /// <summary>
+        /// Add player data to ReplacingPlayers dictionary.
+        /// </summary>
+        private void AddData(Player player, Player replacement, bool is079 = false)
+        {
+            try
+            {
+                if (is079)
+                {
+                    if (player.RoleBase is Scp079Role scp079Role && scp079Role.SubroutineModule.TryGetComponent(out Scp079TierManager tierManager)
+                                                                 && scp079Role.SubroutineModule.TryGetSubroutine(out Scp079AuxManager energyManager))
+                    {
+                        MainHandler.ReplacingPlayers.Add(replacement, new AFKData
+                        {
+                            NickName = player.Nickname,
+                            Position = player.Position,
+                            Role = player.Role,
+                            Ammo = null,
+                            Health = player.Health,
+                            Items = player.GetItems(),
+                            SCP079 = new Scp079Data
+                            {
+                                Role = scp079Role,
+                                Energy = energyManager.CurrentAux,
+                                Experience = tierManager.TotalExp,
+                            }
+                        });
+                    }
+                
+                    return;
+                }
+            
+                // If I make Ammo = player.ReferenceHub.inventory.UserInventory.ReserveAmmo for some reason it gets buggy and ammo becomes null when changing the player to spectator.
+                // So I create a temporary dictionary stored in cache (ram) and then clean the information by deleting it from the ReplacingPlayers.
+                var ammo = GetAmmo(player);
+                MainHandler.ReplacingPlayers.Add(replacement, new AFKData
+                {
+                    NickName = player.Nickname,
+                    Position = player.Position,
+                    Role = player.Role,
+                    Ammo = ammo,
+                    Health = player.Health,
+                    Items = player.GetItems(),
+                    SCP079 = new Scp079Data
+                    {
+                        Role = null,
+                        Energy = 0f,
+                        Experience = 0
+                    }
+                });
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Error on {nameof(AddData)}: {e.Data} -- {e.StackTrace}");
+            }
+        }
+        
+        /// <summary>
+        /// Cache player's ammunition
+        /// </summary>
+        /// <param name="player"></param>
+        /// <returns></returns>
+        private Dictionary<ItemType, ushort> GetAmmo(Player player)
+        {
+            var result = new Dictionary<ItemType, ushort>();
+
+            foreach (var ammo in player.ReferenceHub.inventory.UserInventory.ReserveAmmo)
+            {
+                result.Add(ammo.Key, ammo.Value);
+            }
+
+            return result;
+        }
+    }
+}

--- a/UltimateAFK/Config.cs
+++ b/UltimateAFK/Config.cs
@@ -47,5 +47,32 @@ namespace UltimateAFK
 
         [Description("When a player replaces another player, this message will appear on the player's face and on the player console. | {0} it is the name of the player who was afk")]
         public string MsgReplace { get; set; } = "<color=red> You replaced {0} who was afk.</color>";
+
+        [Description("All configuration related with the command")]
+        public CommandConfig CommandConfig { get; set; } = new();
+    }
+
+    public class CommandConfig
+    {
+        [Description("Is the command enabled on this server ?")]
+        public bool IsEnabled { get; set; } = false;
+
+        // Maybe one day... Commands load before singleton is created so i can get config
+        /*[Description("the prefix to be used by the players .afk or whatever you like")]
+        public string Command { get; set; } = "afk";
+
+        [Description("I recommend you not to leave this empty since a bug crashes the server if you register commands with empty aliases.")]
+        public string[] Aliases { get; set; } = new[] { "uafk" };
+
+        [Description("The command description")]
+        public string Description { get; set; } = "By using this command you will be moved to spectator and if the server allows it a player will replace you.";
+        */
+        
+        [Description("Players who use this command will be replaced by players who are in spectator")]
+        public bool Replace { get; set; } = true;
+
+        public string TextOnDisable = "This command is disabled";
+
+        public string TextOnSucces = "You were moved to spectator because you considered yourself AFK.";
     }
 }

--- a/UltimateAFK/Handlers/MainHandler.cs
+++ b/UltimateAFK/Handlers/MainHandler.cs
@@ -84,8 +84,8 @@ namespace UltimateAFK.Handlers
                 {
                     ply.SendBroadcast(string.Format(UltimateAFK.Singleton.Config.MsgReplace, data.NickName), 16, shouldClearPrevious: true);
                     ply.SendConsoleMessage(string.Format(UltimateAFK.Singleton.Config.MsgReplace, data.NickName), "white");
-
-                    tierManager.TotalExp = data.SCP079.Experience;
+                    
+                    tierManager.ServerGrantExperience(data.SCP079.Experience, Scp079HudTranslation.Experience);
                     energyManager.CurrentAux = data.SCP079.Energy;
                     ReplacingPlayers.Remove(ply);
                     

--- a/UltimateAFK/UltimateAFK.cs
+++ b/UltimateAFK/UltimateAFK.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using GameCore;
+using Interactables.Interobjects.DoorUtils;
 using PluginAPI.Core;
 using PluginAPI.Core.Attributes;
 using PluginAPI.Enums;
@@ -19,13 +21,13 @@ namespace UltimateAFK
         [PluginConfig] public Config Config;
         
         [PluginPriority(LoadPriority.High)]
-        [PluginEntryPoint("UltimateAFK", "6.1.0", "Checks if a player is afk for too long and if detected as afk will be replaced by a spectator.", "SrLicht")]
+        [PluginEntryPoint("UltimateAFK", "6.1.1", "Checks if a player is afk for too long and if detected as afk will be replaced by a spectator.", "SrLicht")]
         void OnEnabled()
         {
             Singleton = this;
             PluginAPI.Events.EventManager.RegisterEvents(this, new Handlers.MainHandler(Singleton));
             
-            if (ConfigFile.ServerConfig.GetFloat("afk_time", 90f) > 0)
+            if (ConfigFile.ServerConfig.GetFloat("afk_time") > 1)
             {
                 Log.Warning($"You have enabled the AFK detector of the base game, please disable it by config &6afk_time = 0&r in &4config_gameplay.txt&r");
             }


### PR DESCRIPTION
* Now if the configuration allows it, players can use a command to be considered afk and be moved to spectator and have a player replace them.

* Changed the method of how experience is given to SCP-079. I had reports of a bug that made the lockdown skill have 575 seconds of cooldown, I don't know if this is my problem but just in case.