### PR TITLE
Fix 079 overcharge

### DIFF
--- a/UltimateAFK/Resources/Component/AFKComponent.cs
+++ b/UltimateAFK/Resources/Component/AFKComponent.cs
@@ -188,12 +188,12 @@ namespace UltimateAFK.Resources.Component
                 player.SendBroadcast(Plugin.Config.MsgFspec, 25, shouldClearPrevious: true);
                 player.SendConsoleMessage(Plugin.Config.MsgFspec, "white");
 
-                Log.Debug($"Changing player {player.Nickname} to spectator", Plugin.Config.DebugMode);
-                // Sends player to spectator
-                player.SetRole(RoleTypeId.Spectator);
                 // Sends replacement to the role that had the afk
                 Log.Debug($"Changing replacement player  {replacement.Nickname} role to {roleType}", Plugin.Config.DebugMode);
                 replacement.SetRole(roleType);
+                // Sends player to spectator
+                Log.Debug($"Changing player {player.Nickname} to spectator", Plugin.Config.DebugMode);
+                player.SetRole(RoleTypeId.Spectator);
 
             }
         }


### PR DESCRIPTION
Fixes [this](https://cdn.discordapp.com/attachments/659406227301859328/1113485544563949638/bug_-_Made_with_Clipchamp.mp4) bug that sets 079 into overcharge when only 2 SCPs exist because of "solo 079" detection.
Worked for me, might want to test it on your side as well.