### PR TITLE
Dev

### DIFF
--- a/UltimateAFK/API/Extensions.cs
+++ b/UltimateAFK/API/Extensions.cs
@@ -8,6 +8,7 @@ using PlayerRoles;
 using PlayerRoles.PlayableScps.Scp079;
 using PlayerRoles.Spectating;
 using PluginAPI.Core;
+using PluginAPI.Core.Attributes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -120,7 +121,10 @@ namespace UltimateAFK.API
 
                 if (replacement == null)
                 {
-                    Log.Debug("Unable to find replacement player, moving to spectator...", EntryPoint.Instance.Config.DebugMode);
+                    if (EntryPoint.Instance.Config.DisableReplacement)
+                        Log.Debug("AFK player replacement is disabled by the plugin configuration.", EntryPoint.Instance.Config.DebugMode);
+                    else
+                        Log.Debug("Unable to find replacement player, moving to spectator...", EntryPoint.Instance.Config.DebugMode);
 
                     player.ClearInventory();
 
@@ -315,6 +319,10 @@ namespace UltimateAFK.API
         {
             try
             {
+                // Return null if replacement is disable
+                if (EntryPoint.Instance.Config.DisableReplacement)
+                    return null;
+
                 Player? longestSpectator = null;
                 float maxActiveTime = 0f;
 

--- a/UltimateAFK/Config.cs
+++ b/UltimateAFK/Config.cs
@@ -24,6 +24,13 @@ namespace UltimateAFK
 
         // copy from repository
 
+
+        /// <summary>
+        /// Gets or sets if the replacement of afk player is disabled.
+        /// </summary>
+        [Description("Setting this to true will cause players who are detected afk not to be replaced but only moved to spectator/kicked of the server.")]
+        public bool DisableReplacement { get; set; } = false;
+
         /// <summary>
         /// Gets or sets the deplay for replacing players.
         /// </summary>

--- a/UltimateAFK/EntryPoint.cs
+++ b/UltimateAFK/EntryPoint.cs
@@ -23,7 +23,7 @@ namespace UltimateAFK
         /// <summary>
         /// Gets the plugin version.
         /// </summary>
-        public const string Version = "7.0.3";
+        public const string Version = "7.0.4";
 
         /// <summary>
         /// Called when loading the plugin

--- a/UltimateAFK/UltimateAFK.csproj
+++ b/UltimateAFK/UltimateAFK.csproj
@@ -22,7 +22,6 @@
  </ItemGroup>
 
  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Lib.Harmony" Version="2.2.2" />
   </ItemGroup>
 


### PR DESCRIPTION
* Added disable replacement in the config file

* The permission 'uafk.detectiondisabled' has been added and it will disable the detection of afk but not the replacement, players with uafk.detectiondisabled can be replace players afk

* recompile for christmas update